### PR TITLE
Add copy invite code button to settings screen

### DIFF
--- a/src/js/pages/room/index.js
+++ b/src/js/pages/room/index.js
@@ -529,10 +529,37 @@ const Settings = ({open}) => {
   // Hooks
   //
   const [screen, setScreen] = useState(SETTINGS_SCREEN_MENU);
+  const [codeCopied, setCodeCopied] = useState(false);
+  const inviteCode = useSelector(BuoySelectors.connectedBuoy).get('token');
+
+  ////
+  // Action callbacks
+  //
+  const copyInviteCode = () => {
+    const dummy = document.createElement('textarea');
+    dummy.value = inviteCode;
+    document.body.appendChild(dummy);
+    dummy.select();
+    document.execCommand('copy');
+    document.body.removeChild(dummy);
+
+    setCodeCopied(true);
+    setTimeout(() => {
+      setCodeCopied(false);
+    }, 2000);
+  };
 
   ////
   // Rendering
   //
+  let copyText;
+
+  if (codeCopied) {
+    copyText = '✅ copied!';
+  } else {
+    copyText = '🔗 copy invite code';
+  }
+
   return (
     <div
       className={classNames(['room--settings', {open}])}
@@ -545,6 +572,9 @@ const Settings = ({open}) => {
               report a bug
             </li>
           </ul>
+          <a className={classNames(['invite-code-link', {success: codeCopied}])} onClick={() => copyInviteCode()}>
+            {copyText}
+          </a>
         </div>
       )}
       {screen === SETTINGS_SCREEN_EDIT_PROFILE && (

--- a/src/scss/pages/room.scss
+++ b/src/scss/pages/room.scss
@@ -453,6 +453,7 @@ $nowplaying-height: 85px;
   .settings--menu {
     transform: scale(0);
     transition: 200ms;
+    text-align: center;
   }
 
   &.open {


### PR DESCRIPTION
This is probably a stopgap until there's things like single-use invite URLs to invite people to a buoy with.

Fixes #12 

![2019-06-26 10 44 02](https://user-images.githubusercontent.com/284902/60189899-b3c50900-97ff-11e9-8474-a6de9da9123c.gif)