### PR TITLE
Fixes losing the focus on textarea in Chrome

### DIFF
--- a/src/js/pages/room/index.js
+++ b/src/js/pages/room/index.js
@@ -401,6 +401,8 @@ const Chat = () => {
   };
 
   const onKeyPress = (e) => {
+    if (sendingMessage) return;
+
     if (e.key === 'Enter') {
       dispatch(RoomActions.sendChat());
       e.preventDefault();
@@ -437,7 +439,6 @@ const Chat = () => {
       <div className="chat--compose">
         <textarea
           placeholder="type it and hit enter"
-          disabled={sendingMessage}
           onChange={onChange}
           value={newMessage}
           onKeyPress={onKeyPress}


### PR DESCRIPTION
After a bit of investigation 🧐 I found out that the focus was being
lost when the textarea is disabled. Only Chrome has this behavior afaik.

The proposed solution avoids changing the enabled/disabled status
of the textarea and instead has a guard in the `onKeyPress` callback that
will prevent re-sending the message if another one is being sent
already.

Closes #30 